### PR TITLE
Allow middleware to be used by non express tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ function createGhSecureWebhookMiddleware() {
   return function middleware(req, res, next) {
     bodyParser.json()(req, res, function () {
       const ctx = req.webtaskContext;
-
+      
+      //ensure that the context uses the parsed body
+      ctx.body = req.body;
+      
       if (ctx.secrets && ctx.secrets[AUTH_SECRET_NAME]) {
         const hash = crypto
                       .createHmac('sha1', ctx.secrets[AUTH_SECRET_NAME])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secure-github-webhook",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "This webtask middleware helps to secure your GitHub webhook",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
This seems to work for both test cases for me.